### PR TITLE
Fixes #7 – Add hints for Identity & Telemetry Custom Queries 

### DIFF
--- a/nodes/Dimo/Dimo.node.ts
+++ b/nodes/Dimo/Dimo.node.ts
@@ -38,6 +38,18 @@ export class Dimo implements INodeType {
 		version: 1,
 		subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
 		description: 'Interact with the DIMO API',
+		hints: [
+			{
+				message: 'It is recommended that you test your Identity queries in the Identity API Playground before using them in n8n: https://identity-api.dimo.zone/',
+				type: 'warning',
+				displayCondition: '={{ $parameter["resource"] === "identity" && $parameter["operation"] === "customIdentity" }}',
+			},
+			{
+				message: 'It is recommended that you test your Telemetry queries in the Telemetry API Playground before using them in n8n: https://telemetry-api.dimo.zone/',
+				type: 'warning',
+				displayCondition: '={{ $parameter["resource"] === "telemetry" && $parameter["operation"] === "customTelemetry" }}',
+			}
+		],
 		defaults: {
 			name: 'DIMO',
 		},


### PR DESCRIPTION
Per Issue 7, this adds a hint label for custom queries to Identity & Telemetry:

- Uses yellow "warning" type for visibility purposes (not sure if n8n will flag as this being more "info" but it's harder to see when gray)
- Only affects custom queries, not built in 
![CleanShot 2025-02-10 at 08 57 27](https://github.com/user-attachments/assets/6bda45af-26f9-4661-8ce5-1517c67ab999)
