### PR TITLE
Rename Vehicle Events + Easier Data Selector for Webhooks

### DIFF
--- a/nodes/Dimo/Dimo.node.ts
+++ b/nodes/Dimo/Dimo.node.ts
@@ -21,8 +21,8 @@ import { trips } from './operations/Trips';
 import { tripsDescription } from './descriptions/TripsDescription';
 import { valuations } from './operations/Valuations';
 import { valuationsDescription } from './descriptions/ValuationsDescription';
-import { vehicleEvents } from './operations/VehicleEvents';
-import { vehicleEventsDescription } from './descriptions/VehicleEventsDescription';
+import { webhooks } from './operations/Webhooks';
+import { webhooksDescription } from './descriptions/WebhooksDescription';
 
 const resourceOperations = new Map([
 	['authentication', authentication.execute],
@@ -32,7 +32,7 @@ const resourceOperations = new Map([
 	['telemetry', telemetry.execute],
 	['trips', trips.execute],
 	['valuations', valuations.execute],
-	['vehicleevents', vehicleEvents.execute],
+	['webhooks', webhooks.execute],
 ])
 
 export class Dimo implements INodeType {
@@ -67,6 +67,13 @@ export class Dimo implements INodeType {
 				required: true,
 			},
 		],
+		requestDefaults: {
+			baseURL: 'https://api.dimo.zone',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+		},
 		properties: [
 			{
 				displayName: 'Resource',
@@ -103,8 +110,8 @@ export class Dimo implements INodeType {
 						value: 'valuations',
 					},
 					{
-						name: 'Vehicle Events API',
-						value: 'vehicleevents',
+						name: 'Webhooks API',
+						value: 'webhooks',
 					},
 				],
 				default: 'attestation',
@@ -130,9 +137,9 @@ export class Dimo implements INodeType {
 			// Valuations Options
 			valuationsDescription.operations,
 			...valuationsDescription.properties,
-			// Vehicle Events Options
-			vehicleEventsDescription.operations,
-			...vehicleEventsDescription.properties,
+			// Webhooks Options
+			webhooksDescription.operations,
+			...webhooksDescription.properties,
 		],
 	};
 

--- a/nodes/Dimo/descriptions/VehicleEventsDescription.ts
+++ b/nodes/Dimo/descriptions/VehicleEventsDescription.ts
@@ -190,6 +190,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		displayName: 'Verification Token',
 		name: 'verificationToken',
 		type: 'string',
+		typeOptions: { password: true },
 		displayOptions: {
 			show: {
 				resource: ['vehicleevents'],

--- a/nodes/Dimo/descriptions/WebhooksDescription.ts
+++ b/nodes/Dimo/descriptions/WebhooksDescription.ts
@@ -1,13 +1,13 @@
 import { INodeProperties } from 'n8n-workflow';
 
-export const vehicleEventsOperations: INodeProperties = {
+export const webhooksOperations: INodeProperties = {
 	displayName: 'Operation',
 	name: 'operation',
 	type: 'options',
 	noDataExpression: true,
 	displayOptions: {
 		show: {
-			resource: ['vehicleevents'],
+			resource: ['webhooks'],
 		},
 	},
 	options: [
@@ -70,14 +70,27 @@ export const vehicleEventsOperations: INodeProperties = {
 	default: 'getAllWebhooks',
 };
 
-export const vehicleEventsProperties: INodeProperties[] = [
+export const webhooksProperties: INodeProperties[] = [
+	{
+		displayName: 'Resource',
+		name: 'resource',
+		type: 'options',
+		noDataExpression: true,
+		options: [
+			{
+				name: 'Webhooks',
+				value: 'webhooks',
+			},
+		],
+		default: 'webhooks',
+	},
 	{
 		displayName: 'Service',
 		name: 'service',
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -91,7 +104,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -105,7 +118,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -136,7 +149,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		],
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -150,7 +163,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -164,7 +177,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -178,7 +191,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -193,7 +206,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		typeOptions: { password: true },
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
@@ -207,7 +220,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['deleteWebhook', 'updateWebhook', 'subscribeVehicleToWebhook', 'unsubscribeVehicleFromWebhook', 'subscribeAllVehiclesToWebhook', 'unsubscribeAllVehiclesFromWebhook', 'listVehiclesSubscribedToWebhook'],
 			},
 		},
@@ -221,7 +234,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 		type: 'number',
 		displayOptions: {
 			show: {
-				resource: ['vehicleevents'],
+				resource: ['webhooks'],
 				operation: ['subscribeVehicleToWebhook', 'unsubscribeVehicleFromWebhook', 'getVehicleWebhookSubscriptions'],
 			},
 		},
@@ -231,7 +244,7 @@ export const vehicleEventsProperties: INodeProperties[] = [
 	},
 ];
 
-export const vehicleEventsDescription = {
-	operations: vehicleEventsOperations,
-	properties: vehicleEventsProperties,
+export const webhooksDescription = {
+	operations: webhooksOperations,
+	properties: webhooksProperties,
 };

--- a/nodes/Dimo/descriptions/WebhooksDescription.ts
+++ b/nodes/Dimo/descriptions/WebhooksDescription.ts
@@ -72,19 +72,6 @@ export const webhooksOperations: INodeProperties = {
 
 export const webhooksProperties: INodeProperties[] = [
 	{
-		displayName: 'Resource',
-		name: 'resource',
-		type: 'options',
-		noDataExpression: true,
-		options: [
-			{
-				name: 'Webhooks',
-				value: 'webhooks',
-			},
-		],
-		default: 'webhooks',
-	},
-	{
 		displayName: 'Service',
 		name: 'service',
 		type: 'string',

--- a/nodes/Dimo/descriptions/WebhooksDescription.ts
+++ b/nodes/Dimo/descriptions/WebhooksDescription.ts
@@ -88,14 +88,76 @@ export const webhooksProperties: INodeProperties[] = [
 	{
 		displayName: 'Data',
 		name: 'data',
-		type: 'string',
+		type: 'options',
+		options: [
+			{
+				name: 'Battery Current Power',
+				value: 'powertrainTractionBatteryCurrentPower',
+				description: 'Current electrical energy flowing in/out of battery. Positive = Energy flowing in to battery, e.g. during charging. Negative = Energy flowing out of battery, e.g. during driving.',
+		},
+			{
+				name: 'Battery Is Charging',
+				value: 'powertrainTractionBatteryChargingIsCharging',
+				description: 'True if charging is ongoing. Charging is considered to be ongoing if energy is flowing from charger to vehicle. True (1) - Vehicle is charging.False (0) - Vehicle is not charging.',
+			},
+			{
+				name: 'Charge Level',
+				value: 'powertrainTractionBatteryStateOfChargeCurrent',
+				description: 'Physical state of charge of the high voltage battery, relative to net capacity. This is not necessarily the state of charge being displayed to the customer.',
+			},
+			{
+				name: 'Fuel Level in Liters',
+				value: 'powertrainFuelSystemAbsoluteLevel',
+				description: 'TCurrent available fuel in the fuel tank expressed in litersbd',
+			},
+			{
+				name: 'Fuel Level Percentage',
+				value: 'powertrainFuelSystemRelativeLevel',
+				description: 'Current available fuel in the fuel tank in %, from 0 to 100',
+			},
+			{
+				name: 'Is Ignition On',
+				value: 'isIgnitionOn',
+				description: 'Vehicle ignition status. True (1) = Vehicle Ignition On. False (0) = Vehicle Ignition Off',
+			},
+			{
+				name: 'Odometer',
+				value: 'powertrainTransmissionTravelledDistance',
+				description: 'Odometer reading in kilometers, total distance travelled during the lifetime of the transmission',
+			},
+			{
+				name: 'Speed',
+				value: 'speed',
+				description: 'The vehicle speed in km/hr',
+			},
+			{
+				name: 'Tire Pressure - Back Left',
+				value: 'chassisAxleRow2WheelLeftTirePressure',
+				description: 'Tire pressure of the rear left tire in kilo-Pascal',
+			},
+			{
+				name: 'Tire Pressure - Back Right',
+				value: 'chassisAxleRow2WheelRightTirePressure',
+				description: 'Tire pressure of the rear right tire in kilo-Pascal',
+			},
+			{
+				name: 'Tire Pressure - Front Left',
+				value: 'chassisAxleRow1WheelLeftTirePressure',
+				description: 'Tire pressure of the front left tire in kilo-Pascal',
+			},
+			{
+				name: 'Tire Pressure - Front Right',
+				value: 'chassisAxleRow1WheelRightTirePressure',
+				description: 'Tire pressure of the front right tire in kilo-Pasca',
+			},
+		],
 		displayOptions: {
 			show: {
 				resource: ['webhooks'],
 				operation: ['registerWebhook', 'updateWebhook'],
 			},
 		},
-		default: '',
+		default: 'powertrainTransmissionTravelledDistance',
 		description: 'The Telemetry field that the webhook will listen for events on',
 		required: true,
 	},

--- a/nodes/Dimo/operations/Webhooks.ts
+++ b/nodes/Dimo/operations/Webhooks.ts
@@ -1,8 +1,8 @@
 import { INodeProperties } from 'n8n-workflow';
-import { vehicleEventsProperties } from '../descriptions/VehicleEventsDescription';
+import { webhooksProperties } from '../descriptions/WebhooksDescription';
 import { DimoHelper } from '../DimoHelper';
 
-const vehicleEventsReqs = new Map([
+const webhooksReqs = new Map([
   ['getAllWebhooks', async (helper: DimoHelper, developerJwt: string, basePath: string) => {
     const response = await helper.executeFunctions.helpers.request({
       method: 'GET',
@@ -193,9 +193,9 @@ const vehicleEventsReqs = new Map([
   }],
 ]);
 
-export const vehicleEvents = {
+export const webhooks = {
 	getProperties(): INodeProperties[] {
-		return vehicleEventsProperties;
+		return webhooksProperties;
 	},
 
 	async execute(helper: DimoHelper, operation: string) {
@@ -206,7 +206,7 @@ export const vehicleEvents = {
 				? 'https://vehicle-events-api.dev.dimo.zone'
 				: 'https://vehicle-events-api.dimo.zone';
 
-		const executeOperation = vehicleEventsReqs.get(operation);
+		const executeOperation = webhooksReqs.get(operation);
 		if (!executeOperation) {
 			throw new Error(`The operation ${operation} is not supported.`);
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-dimo-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "DIMO API Integration for n8n",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
This update changes the name `Vehicle Events` to `Webhooks`.

It also updates the data field for webhook registration into a dropdown, for easier selection similar to the developer console, and leaves less room for error. 